### PR TITLE
Derniers correctifs:

### DIFF
--- a/src/myerp-business/src/main/java/com/dummy/myerp/business/contrat/manager/ComptabiliteManager.java
+++ b/src/myerp-business/src/main/java/com/dummy/myerp/business/contrat/manager/ComptabiliteManager.java
@@ -49,8 +49,9 @@ public interface ComptabiliteManager {
      *
      * <p><strong>Attention :</strong> l'écriture n'est pas enregistrée en persistance</p>
      * @param pEcritureComptable L'écriture comptable concernée
+     * @throws FunctionalException 
      */
-    void addReference(EcritureComptable pEcritureComptable);
+    void addReference(EcritureComptable pEcritureComptable) throws FunctionalException;
 
     /**
      * Vérifie que l'Ecriture comptable respecte les règles de gestion.

--- a/src/myerp-business/src/main/java/com/dummy/myerp/business/impl/manager/ComptabiliteManagerImpl.java
+++ b/src/myerp-business/src/main/java/com/dummy/myerp/business/impl/manager/ComptabiliteManagerImpl.java
@@ -83,10 +83,11 @@ public class ComptabiliteManagerImpl extends AbstractBusinessManager implements 
 
     /**
      * {@inheritDoc}
+     * @throws FunctionalException 
      */
     @SuppressWarnings("deprecation")
     @Override
-    public synchronized void addReference(EcritureComptable pEcritureComptable) {
+    public synchronized void addReference(EcritureComptable pEcritureComptable) throws FunctionalException {
     	SequenceEcritureComptable sequenceEcritureComptable;
     	try {
     		// 1) Remonter la derniere valeur de la séquence
@@ -99,7 +100,7 @@ public class ComptabiliteManagerImpl extends AbstractBusinessManager implements 
 			// 3) Référence
 			pEcritureComptable.setReference(getEcritureComptableReference(sequenceEcritureComptable));
 			// 4) Update de la séquence écriture comptable
-			this.getDaoProxy().getComptabiliteDao().updateSequenceEcritureComptable(sequenceEcritureComptable);
+			updateSequenceEcritureComptable(sequenceEcritureComptable);
 		} catch (NotFoundException e) {
 			// 2) Dernière valeur = 1
 			sequenceEcritureComptable = new SequenceEcritureComptable();
@@ -109,7 +110,7 @@ public class ComptabiliteManagerImpl extends AbstractBusinessManager implements 
 			// 3) Référence
 			pEcritureComptable.setReference(getEcritureComptableReference(sequenceEcritureComptable));
 			// 4) Insertion de la séquence en BDD
-			this.getDaoProxy().getComptabiliteDao().createSequenceEcritureComptable(sequenceEcritureComptable);
+			insertSequenceEcritureComptable(sequenceEcritureComptable);
 		}
     }
 
@@ -216,6 +217,33 @@ public class ComptabiliteManagerImpl extends AbstractBusinessManager implements 
     }
 
     /**
+     * 
+     */
+    private void insertSequenceEcritureComptable(SequenceEcritureComptable pSequenceEcritureComptable) throws FunctionalException {
+        TransactionStatus vTS = getTransactionManager().beginTransactionMyERP();
+        try {
+        	getDaoProxy().getComptabiliteDao().createSequenceEcritureComptable(pSequenceEcritureComptable);
+            getTransactionManager().commitMyERP(vTS);
+            vTS = null;
+        } finally {
+            getTransactionManager().rollbackMyERP(vTS);
+        }
+    }
+
+    /**
+     */
+    private void updateSequenceEcritureComptable(SequenceEcritureComptable pSequenceEcritureComptable) throws FunctionalException {
+        TransactionStatus vTS = getTransactionManager().beginTransactionMyERP();
+        try {
+        	getDaoProxy().getComptabiliteDao().updateSequenceEcritureComptable(pSequenceEcritureComptable);
+            getTransactionManager().commitMyERP(vTS);
+            vTS = null;
+        } finally {
+            getTransactionManager().rollbackMyERP(vTS);
+        }
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -236,6 +264,7 @@ public class ComptabiliteManagerImpl extends AbstractBusinessManager implements 
      */
     @Override
     public void updateEcritureComptable(EcritureComptable pEcritureComptable) throws FunctionalException {
+        this.checkEcritureComptable(pEcritureComptable);
         TransactionStatus vTS = getTransactionManager().beginTransactionMyERP();
         try {
             getDaoProxy().getComptabiliteDao().updateEcritureComptable(pEcritureComptable);

--- a/src/myerp-business/src/test-business/java/com/dummy/myerp/testbusiness/business/ComptabiliteManagerTest.java
+++ b/src/myerp-business/src/test-business/java/com/dummy/myerp/testbusiness/business/ComptabiliteManagerTest.java
@@ -1,0 +1,281 @@
+package com.dummy.myerp.testbusiness.business;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.core.annotation.Order;
+
+import com.dummy.myerp.business.contrat.manager.ComptabiliteManager;
+import com.dummy.myerp.model.bean.comptabilite.CompteComptable;
+import com.dummy.myerp.model.bean.comptabilite.EcritureComptable;
+import com.dummy.myerp.model.bean.comptabilite.JournalComptable;
+import com.dummy.myerp.model.bean.comptabilite.LigneEcritureComptable;
+import com.dummy.myerp.technical.exception.FunctionalException;
+
+public class ComptabiliteManagerTest extends BusinessTestCase {
+	
+	private ComptabiliteManager comptabiliteManager;
+
+    private EcritureComptable buildEcritureComptable(String libelle, String reference, Date date, JournalComptable journal) {
+    	EcritureComptable ecritureComptable = new EcritureComptable();
+    	
+    	ecritureComptable.setLibelle(libelle);
+    	ecritureComptable.setReference(reference);
+    	ecritureComptable.setDate(date);
+    	ecritureComptable.setJournal(journal);
+    	return ecritureComptable;
+    }
+	
+	@Before
+	public void init() {
+		comptabiliteManager = getBusinessProxy().getComptabiliteManager();
+	}
+	
+	@Test
+	public void testGetListCompteComptable() {
+		List<CompteComptable> ccList = comptabiliteManager.getListCompteComptable();
+		assertEquals(7, ccList.size());
+	}
+	
+	@Test
+	public void testGetListJournalComptable() {
+		List<JournalComptable> ccList = comptabiliteManager.getListJournalComptable();
+		assertEquals(4, ccList.size());
+	}
+	
+	@Test
+	public void testGetListEcritureComptable() {
+		List<EcritureComptable> ccList = comptabiliteManager.getListEcritureComptable();
+		assertEquals(6, ccList.size());
+	}
+	
+	@Test
+	public void testAddReferenceOKNewSequence() throws FunctionalException {
+		JournalComptable jc = new JournalComptable("AC", "Achat");
+		EcritureComptable ec = new EcritureComptable();
+		Date d = new Date(2018, 01, 01);
+		ec.setJournal(jc);
+		ec.setDate(d);
+		ec.setLibelle("Premiere EcritureComptable pour 2018");
+		
+		comptabiliteManager.addReference(ec);
+		assertEquals("AC-2018/00001", ec.getReference());
+	}
+	
+	@Test
+	public void testAddReferenceOKExistingSequence() throws FunctionalException {
+		JournalComptable jc = new JournalComptable("AC", "Achat");
+		EcritureComptable ec = new EcritureComptable();
+		Date d = new Date(2016, 01, 01);
+		ec.setJournal(jc);
+		ec.setDate(d);
+		ec.setLibelle("41eme EcritureComptable pour 2016");
+		
+		comptabiliteManager.addReference(ec);
+		assertEquals("AC-2016/00041", ec.getReference());
+	}
+	
+	@Test(expected = NullPointerException.class)
+	public void testAddReferenceKOEcritureNull() throws FunctionalException {
+		comptabiliteManager.addReference(null);
+	}
+	
+	@Test(expected = NullPointerException.class)
+	public void testAddReferenceKOEcritureJournalNull() throws FunctionalException {
+		EcritureComptable ec = new EcritureComptable();
+		ec.setDate(new Date());
+		comptabiliteManager.addReference(ec);
+	}
+	
+	@Test(expected = NullPointerException.class)
+	public void testAddReferenceKOEcritureDateNull() throws FunctionalException {
+		EcritureComptable ec = new EcritureComptable();
+		ec.setJournal(new JournalComptable("AC", "Achat"));
+		comptabiliteManager.addReference(ec);
+	}
+	
+	@Test
+	public void testCheckEcritureComptableOK() throws FunctionalException {
+		// Ici pas de assert : si aucune exception n'est levée, l'Ecriture est OK
+        EcritureComptable vEcritureComptable = buildEcritureComptable(
+        		"Libelle",
+        		"AC-2016/00042",
+        		new Date(2016, 04, 05),
+        		new JournalComptable("AC", "Achat"));
+        
+        vEcritureComptable.getListLigneEcriture().add(
+        		new LigneEcritureComptable(new CompteComptable(411, "Client"), "Debit X", new BigDecimal(123), null)
+		);
+        vEcritureComptable.getListLigneEcriture().add(
+        		new LigneEcritureComptable(new CompteComptable(401, "Fournisseurs"), "Credit X", null, new BigDecimal(123))
+		);
+		comptabiliteManager.checkEcritureComptable(vEcritureComptable);
+	}
+	
+	@Test(expected = FunctionalException.class)
+	public void testCheckEcritureComptableKOConstraint() throws FunctionalException {
+		// L'id du compte comptable n'est pas renseigné ici
+        EcritureComptable vEcritureComptable = buildEcritureComptable(
+        		"Libelle",
+        		"AC-2019/00001",
+        		new Date(2019, 04, 05),
+        		new JournalComptable("AC", "Achat"));
+        
+        vEcritureComptable.getListLigneEcriture().add(
+        		new LigneEcritureComptable(new CompteComptable(1, "CompteA"), "Debit X", new BigDecimal(123), null)
+		);
+        vEcritureComptable.getListLigneEcriture().add(
+        		new LigneEcritureComptable(new CompteComptable(null, "CompteB"), "Credit X", null, new BigDecimal(123))
+		);
+		comptabiliteManager.checkEcritureComptable(vEcritureComptable);
+	}
+	
+	@Test(expected = FunctionalException.class)
+	public void testCheckEcritureComptableKOEquilibree() throws FunctionalException {
+		// Les lignes ne sont pas équilibrée (debit - credit != 0)
+        EcritureComptable vEcritureComptable = buildEcritureComptable(
+        		"Libelle",
+        		"AC-2019/00001",
+        		new Date(2019, 04, 05),
+        		new JournalComptable("AC", "Achat"));
+        
+        vEcritureComptable.getListLigneEcriture().add(
+        		new LigneEcritureComptable(new CompteComptable(1, "CompteA"), "Debit X", new BigDecimal(123), null)
+		);
+        vEcritureComptable.getListLigneEcriture().add(
+        		new LigneEcritureComptable(new CompteComptable(2, "CompteB"), "Credit X", null, new BigDecimal(124))
+		);
+		comptabiliteManager.checkEcritureComptable(vEcritureComptable);
+	}
+	
+	@Test(expected = FunctionalException.class)
+	public void testCheckEcritureComptableKOExisting() throws FunctionalException {
+		// Il existe déjà une même référence
+        EcritureComptable vEcritureComptable = buildEcritureComptable(
+        		"Libelle",
+        		"AC-2016/00001",
+        		new Date(2016, 04, 05),
+        		new JournalComptable("AC", "Achat"));
+        
+        vEcritureComptable.getListLigneEcriture().add(
+        		new LigneEcritureComptable(new CompteComptable(1, "CompteA"), "Debit X", new BigDecimal(123), null)
+		);
+        vEcritureComptable.getListLigneEcriture().add(
+        		new LigneEcritureComptable(new CompteComptable(2, "CompteB"), "Credit X", null, new BigDecimal(123))
+		);
+		comptabiliteManager.checkEcritureComptable(vEcritureComptable);
+	}
+	
+	@Test
+	public void testInsertEcritureComptableOK() throws FunctionalException {
+        EcritureComptable vEcritureComptable = buildEcritureComptable(
+        		"Une ecriture de test",
+        		"AC-2016/00042",
+        		new Date(2016, 04, 05),
+        		new JournalComptable("AC", "Achat"));
+        
+        vEcritureComptable.getListLigneEcriture().add(
+        		new LigneEcritureComptable(new CompteComptable(411, "Client"), "Debit X", new BigDecimal(123), null)
+		);
+        vEcritureComptable.getListLigneEcriture().add(
+        		new LigneEcritureComptable(new CompteComptable(401, "Fournisseurs"), "Credit X", null, new BigDecimal(123))
+		);
+		comptabiliteManager.insertEcritureComptable(vEcritureComptable);
+		assertNotNull(vEcritureComptable.getId());
+	}
+	
+	@Test(expected = FunctionalException.class)
+	public void testInsertEcritureComptableKOChecks() throws FunctionalException {
+		// Il existe déjà une même référence
+        EcritureComptable vEcritureComptable = buildEcritureComptable(
+        		"Libelle",
+        		"AC-2016/00001",
+        		new Date(2016, 04, 05),
+        		new JournalComptable("AC", "Achat"));
+        
+        vEcritureComptable.getListLigneEcriture().add(
+        		new LigneEcritureComptable(new CompteComptable(1, "CompteA"), "Debit X", new BigDecimal(123), null)
+		);
+        vEcritureComptable.getListLigneEcriture().add(
+        		new LigneEcritureComptable(new CompteComptable(2, "CompteB"), "Credit X", null, new BigDecimal(123))
+		);
+		comptabiliteManager.insertEcritureComptable(vEcritureComptable);
+	}
+	
+	@Test
+	public void testUpdateEcritureComptableOK() throws FunctionalException {
+        EcritureComptable vEcritureComptable = buildEcritureComptable(
+        		"Libelle",
+        		"AC-2016/00001",
+        		new Date(2016, 04, 05),
+        		new JournalComptable("AC", "Achat"));
+        
+        vEcritureComptable.getListLigneEcriture().add(
+        		new LigneEcritureComptable(new CompteComptable(411, "Client"), "Debit X", new BigDecimal(123), null)
+		);
+        vEcritureComptable.getListLigneEcriture().add(
+        		new LigneEcritureComptable(new CompteComptable(401, "Fournisseurs"), "Credit X", null, new BigDecimal(123))
+		);
+        vEcritureComptable.setId(-1);
+		comptabiliteManager.updateEcritureComptable(vEcritureComptable);
+	}
+	
+	@Test(expected = FunctionalException.class)
+	public void testUpdateEcritureComptableKODifferentId() throws FunctionalException {
+        EcritureComptable vEcritureComptable = buildEcritureComptable(
+        		"Libelle",
+        		"AC-2016/00001",
+        		new Date(2016, 04, 05),
+        		new JournalComptable("AC", "Achat"));
+        
+        vEcritureComptable.getListLigneEcriture().add(
+        		new LigneEcritureComptable(new CompteComptable(411, "Client"), "Debit X", new BigDecimal(123), null)
+		);
+        vEcritureComptable.getListLigneEcriture().add(
+        		new LigneEcritureComptable(new CompteComptable(401, "Fournisseurs"), "Credit X", null, new BigDecimal(123))
+		);
+        // Pour la référence donnée, l'id de l'écriture comptable ne correspond pas
+        vEcritureComptable.setId(-2);
+		comptabiliteManager.updateEcritureComptable(vEcritureComptable);
+	}
+	
+	private EcritureComptable findEcritureComptableById(Integer id) {
+		return comptabiliteManager.getListEcritureComptable().stream()
+				.filter(ec -> ec.getId().equals(id))
+				.findFirst().orElse(null);
+	}
+
+	@Test
+	public void testLastDeleteEcritureComptableOK() throws FunctionalException {
+        EcritureComptable vEcritureComptable = buildEcritureComptable(
+        		"Une ecriture de test",
+        		"AC-2016/00042",
+        		new Date(2016, 04, 05),
+        		new JournalComptable("AC", "Achat"));
+        
+        vEcritureComptable.getListLigneEcriture().add(
+        		new LigneEcritureComptable(new CompteComptable(411, "Client"), "Debit X", new BigDecimal(123), null)
+		);
+        vEcritureComptable.getListLigneEcriture().add(
+        		new LigneEcritureComptable(new CompteComptable(401, "Fournisseurs"), "Credit X", null, new BigDecimal(123))
+		);
+		comptabiliteManager.insertEcritureComptable(vEcritureComptable);
+		assertNotNull(vEcritureComptable.getId());
+
+		EcritureComptable ecBefore = findEcritureComptableById(vEcritureComptable.getId());
+		comptabiliteManager.deleteEcritureComptable(vEcritureComptable.getId());
+		EcritureComptable ecAfter = findEcritureComptableById(vEcritureComptable.getId());
+
+		assertNotNull(ecBefore);
+		assertNull(ecAfter);
+	}
+}

--- a/src/myerp-business/src/test/java/com/dummy/myerp/business/impl/manager/ComptabiliteManagerImplTest.java
+++ b/src/myerp-business/src/test/java/com/dummy/myerp/business/impl/manager/ComptabiliteManagerImplTest.java
@@ -615,7 +615,7 @@ public class ComptabiliteManagerImplTest {
     }
     
     @Test 
-    public void testAddReference() throws NotFoundException {
+    public void testAddReference() throws NotFoundException, FunctionalException {
     	JournalComptable jc = new JournalComptable("AC", "Achat");
     	EcritureComptable ec = new EcritureComptable();
     	ec.setDate(new Date(2019, 1, 1));
@@ -634,7 +634,7 @@ public class ComptabiliteManagerImplTest {
     }
     
     @Test
-    public void testAddReferenceNew() throws NotFoundException {
+    public void testAddReferenceNew() throws NotFoundException, FunctionalException {
     	JournalComptable jc = new JournalComptable("AC", "Achat");
     	EcritureComptable ec = new EcritureComptable();
     	ec.setDate(new Date(2019, 1, 1));
@@ -739,8 +739,22 @@ public class ComptabiliteManagerImplTest {
     }
     
     @Test
-    public void testUpdateEcritureComptable() throws FunctionalException {
-    	EcritureComptable ec = new EcritureComptable();
+    public void testUpdateEcritureComptable() throws FunctionalException, NotFoundException {
+    	// Ecriture comptable valide
+    	EcritureComptable ec = buildEcritureComptable(
+        		"Libelle",
+        		"AC-2019/00001",
+        		new Date(2019, 04, 05),
+        		new JournalComptable("AC", "Achat"));
+        
+        ec.getListLigneEcriture().add(
+        		new LigneEcritureComptable(new CompteComptable(1, "CompteA"), "Debit X", new BigDecimal(123), null)
+		);
+        ec.getListLigneEcriture().add(
+        		new LigneEcritureComptable(new CompteComptable(2, "CompteB"), "Credit X", null, new BigDecimal(123))
+		);
+        // Unicité de l'écriture comptable
+        Mockito.when(comptabiliteDao.getEcritureComptableByRef("AC-2019/00001")).thenThrow(NotFoundException.class);
     	
     	comptabiliteManager.updateEcritureComptable(ec);
     	Mockito.verify(comptabiliteDao).updateEcritureComptable(ec);

--- a/src/myerp-consumer/src/test/java/com/dummy/myerp/consumer/dao/impl/db/dao/ComptabiliteDaoImplTest.java
+++ b/src/myerp-consumer/src/test/java/com/dummy/myerp/consumer/dao/impl/db/dao/ComptabiliteDaoImplTest.java
@@ -19,7 +19,7 @@ import com.dummy.myerp.model.bean.comptabilite.LigneEcritureComptable;
 import com.dummy.myerp.model.bean.comptabilite.SequenceEcritureComptable;
 import com.dummy.myerp.technical.exception.NotFoundException;
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration("classpath:com/dummy/myerp/consumer/applicationContext.xml")
+@ContextConfiguration("classpath:com/dummy/myerp/consumer/testApplicationContext.xml")
 public class ComptabiliteDaoImplTest {
 	// === Taille des listes
 	private static final int COMPTE_COMPTABLE_NB = 7;

--- a/src/myerp-consumer/src/test/resources/com/dummy/myerp/consumer/testApplicationContext.xml
+++ b/src/myerp-consumer/src/test/resources/com/dummy/myerp/consumer/testApplicationContext.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                        http://www.springframework.org/schema/beans/spring-beans-4.3.xsd">
+
+
+    <!-- ====================   Consumer   ==================== -->
+    <!-- AbstractDbConsumer -->
+    <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+        <property name="targetClass" value="com.dummy.myerp.consumer.db.AbstractDbConsumer"/>
+        <property name="targetMethod" value="configure"/>
+        <property name="arguments">
+            <map>
+                <entry value-ref="dataSourceMYERP">
+                    <key>
+                        <value type="com.dummy.myerp.consumer.db.DataSourcesEnum">MYERP</value>
+                    </key>
+                </entry>
+            </map>
+        </property>
+    </bean>
+
+
+    <!-- ==================== Consumer-Proxy ==================== -->
+
+    <!-- ConsumerHelper -->
+    <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+        <property name="targetClass" value="com.dummy.myerp.consumer.ConsumerHelper"/>
+        <property name="targetMethod" value="configure"/>
+        <property name="arguments">
+            <list>
+                <ref bean="DaoProxy"/>
+            </list>
+        </property>
+    </bean>
+
+
+    <!-- DaoProxy -->
+    <bean id="DaoProxy" class="com.dummy.myerp.consumer.dao.impl.DaoProxyImpl" factory-method="getInstance">
+        <property name="comptabiliteDao" ref="ComptabiliteDaoImpl"/>
+    </bean>
+
+    <!-- ==================== Databases ==================== -->
+    <bean id="dataSourceMYERP" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
+        <property name="driverClassName" value="org.postgresql.Driver"></property>
+        <property name="url" value="jdbc:postgresql://127.0.0.1:9032/db_myerp"></property>
+        <property name="username" value="usr_myerp"></property>
+        <property name="password" value="myerp"></property>
+    </bean>
+
+
+    <!-- ========== SQL ========== -->
+    <import resource="sqlContext.xml"/>
+</beans>


### PR DESCRIPTION
	- ComptabiliteManager.addReference throw une exception
	- L'insert ou l'update d'une séquence passer par une transaction
	- L'update d'une EcritureComptable par ComptabililteManager fait une verification
	- Les tests en lien avec la base de donnée utilise leur propre applicationContext (attention, la datasource indiquée est actuellement la même que hors test)
	- Ajout de tests d'intégration pour le module business